### PR TITLE
feat: add initialize appId/measurementId args

### DIFF
--- a/modules/auth/src/initialize-firebase-app.ts
+++ b/modules/auth/src/initialize-firebase-app.ts
@@ -6,7 +6,9 @@ export const initializeFirebaseApp = ({
   projectId,
   storageBucket,
   messagingSenderId,
-  apiKey
+  apiKey,
+  appId,
+  measurementId
 }: InitializeAppArgs) => {
   try {
     firebase.initializeApp({
@@ -15,7 +17,9 @@ export const initializeFirebaseApp = ({
       databaseURL,
       projectId,
       storageBucket,
-      messagingSenderId
+      messagingSenderId,
+      appId,
+      measurementId
     });
   } catch (err) {
     if (err.code !== "app/duplicate-app") {

--- a/modules/auth/src/types.ts
+++ b/modules/auth/src/types.ts
@@ -6,6 +6,8 @@ export interface InitializeAppArgs {
   projectId: string;
   messagingSenderId?: string;
   storageBucket?: string;
+  appId?: string;
+  measurementId?: string;
 }
 export type FirebaseAuthProviderProps = InitializeAppArgs;
 export type AuthEmission = {

--- a/modules/database/src/initialize-firebase-app.ts
+++ b/modules/database/src/initialize-firebase-app.ts
@@ -1,5 +1,4 @@
 import { InitializeAppArgs } from "./types";
-
 export const initializeFirebaseApp = ({
   firebase,
   authDomain,
@@ -7,7 +6,9 @@ export const initializeFirebaseApp = ({
   projectId,
   storageBucket,
   messagingSenderId,
-  apiKey
+  apiKey,
+  appId,
+  measurementId
 }: InitializeAppArgs) => {
   try {
     firebase.initializeApp({
@@ -16,7 +17,9 @@ export const initializeFirebaseApp = ({
       databaseURL,
       projectId,
       storageBucket,
-      messagingSenderId
+      messagingSenderId,
+      appId,
+      measurementId
     });
   } catch (err) {
     if (err.code !== "app/duplicate-app") {

--- a/modules/database/src/types.ts
+++ b/modules/database/src/types.ts
@@ -23,6 +23,8 @@ export interface InitializeAppArgs {
   projectId?: string;
   messagingSenderId?: string;
   storageBucket?: string;
+  appId?: string;
+  measurementId?: string;
   createContext?: () => any;
 }
 

--- a/modules/firestore/src/initialize-firebase-app.ts
+++ b/modules/firestore/src/initialize-firebase-app.ts
@@ -1,5 +1,4 @@
 import { InitializeAppArgs } from "./types";
-
 export const initializeFirebaseApp = ({
   firebase,
   authDomain,
@@ -7,7 +6,9 @@ export const initializeFirebaseApp = ({
   projectId,
   storageBucket,
   messagingSenderId,
-  apiKey
+  apiKey,
+  appId,
+  measurementId
 }: InitializeAppArgs) => {
   try {
     firebase.initializeApp({
@@ -16,7 +17,9 @@ export const initializeFirebaseApp = ({
       databaseURL,
       projectId,
       storageBucket,
-      messagingSenderId
+      messagingSenderId,
+      appId,
+      measurementId
     });
   } catch (err) {
     if (err.code !== "app/duplicate-app") {

--- a/modules/firestore/src/types.ts
+++ b/modules/firestore/src/types.ts
@@ -52,6 +52,8 @@ export interface InitializeAppArgs {
   projectId: string;
   messagingSenderId?: string;
   storageBucket?: string;
+  appId?: string;
+  measurementId?: string;
 }
 
 export type FirestoreProviderProps = InitializeAppArgs;


### PR DESCRIPTION
Added optional initialize app arguments: `appId` and `measurementId`.

Ran into an issue setting up Firebase Cloud Messaging. Turns out `appId` is required for CM with SDK version 7.2.1+ (firebase/firebase-js-sdk#2287). This change should fix the issue and hopefully prevent similiar ones from happening.