### PR TITLE
allow firestore document collection to receive an array of where clauses

### DIFF
--- a/modules/firestore/src/get-firestore-query.ts
+++ b/modules/firestore/src/get-firestore-query.ts
@@ -55,7 +55,13 @@ export const getFirestoreQuery = ({
   });
 
   if (where !== null) {
-    ref = ref.where(where.field, where.operator, where.value);
+    if (Array.isArray(where)) {
+      for (let whereClause of where) {
+        ref = ref.where(whereClause.field, whereClause.operator, whereClause.value);
+      }
+    } else {
+      ref = ref.where(where.field, where.operator, where.value);
+    }
   }
   if (orderBy !== null) {
     for (let currentOrderBy of orderBy) {

--- a/modules/firestore/src/types.ts
+++ b/modules/firestore/src/types.ts
@@ -3,13 +3,15 @@ export type OrNull<T> = T | null;
 
 export type PrimitiveType = number | boolean | string;
 
+export type WhereType = {
+  field: string;
+  operator: "<" | "<=" | "==" | ">" | ">=" | "array-contains";
+  value: any;
+};
+
 export type FirestoreQuery = {
   path: OrNull<string>;
-  where?: OrNull<{
-    field: string;
-    operator: "<" | "<=" | "==" | ">" | ">=" | "array-contains";
-    value: any;
-  }>;
+  where?: OrNull<WhereType | WhereType[]>;
   orderBy?: OrNull<{ field: string; type?: "desc" | "asc" }[]>;
   limit?: OrNull<number>;
   startAt?: OrNull<PrimitiveType | PrimitiveType[] | DocumentSnapshot>;


### PR DESCRIPTION
Hi,
Thanks for you fantastic work!
I opened this PR to allow compound queries to collections, concatenating .where() cluases over firestore references.

Let me know if I can do anything else!
Thanks

