### PR TITLE
Fixes #19

### DIFF
--- a/modules/auth/src/index.tsx
+++ b/modules/auth/src/index.tsx
@@ -63,9 +63,9 @@ export class FirebaseAuthProvider extends React.PureComponent<
       });
   };
   state = {
-    isSignedIn: false,
+    isSignedIn: !!this.props.firebase.auth().currentUser,
     providerId: null,
-    user: null,
+    user: this.props.firebase.auth().currentUser,
     firebase: {}
   };
   constructor(props: FirebaseAuthProviderProps) {


### PR DESCRIPTION
Your suggested fix for #19:

### Set default user based on `firebase.auth().currentUser` instead of an unknown status until the auth stream is registered.

PS: I ran `npm test` but `tsc && jest` seem to have errors that are not related to my changes. You might wanna review what's causing that. In my environment, these are the errors that occur:

1) Can't find a declaration file for `vfile-message`.
2) Can't find module `firebase/app` or its type declarations.
3) Can't find module `./test-credentials` or its type declarations.